### PR TITLE
chore(circleci): fix build process on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: "0.12"
+    version: "5.1.0"
 test:
   pre:
     - npm run build

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "template-html-loader": "0.0.3",
     "tslint": "^3.2.2",
     "typescript": "^1.7.5",
-    "webpack": "^1.12.10"
+    "typings": "^0.6.5",
+    "webpack": "^1.12.13"
   },
   "peerDependencies": {
     "angular": "^1.4.8",


### PR DESCRIPTION
CircleCI build/release is failing due to incorrect node version, and missing package.json dependencies