### PR TITLE
chore(circleci): Use local versions of CLI commands in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   ],
   "main": "index.js",
   "scripts": {
-    "build": "typings install & npm run tslint & tsc & webpack & webpack --config webpack.demos.config.js",
+    "build": "node_modules/.bin/typings install & npm run tslint & node_modules/.bin/tsc & node_modules/.bin/webpack & node_modules/.bin/webpack --config webpack.demos.config.js",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "tslint": "tslint \"src/**/*.ts\" || true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "tslint": "node_modules/.bin/tslint \"src/**/*.ts\" || true",
+    "semantic-release": "node_modules/.bin/semantic-release pre && npm publish && node_modules/.bin/semantic-release post"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Use local versions e.g. node_modules/.bin/webpack instead of webpack