### PR TITLE
fix(osTabs): Fix double navigation bug

### DIFF
--- a/src/components/popup/docs/popup.demo.service.html
+++ b/src/components/popup/docs/popup.demo.service.html
@@ -11,7 +11,6 @@
       parent: element,
       scope: {
         ngCallback: function() {
-          console.log('Hit callback');
         }
       },
       actions: '<a ng-click="ngCallback()">Action #1</a>'

--- a/src/components/popup/popup.ts
+++ b/src/components/popup/popup.ts
@@ -294,7 +294,6 @@ angular
         angular.element(element[0].getElementsByClassName('placeholder-subtitle')).replaceWith(ctrl.subtitle);
 
         if (ctrl.description.length > 0) {
-          console.log('found description', ctrl.description);
           angular.element(element[0].getElementsByClassName('placeholder-description')).replaceWith(ctrl.description);
         }
 

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -16,6 +16,7 @@ export class OsTab implements IOsTab {
     click(): void|boolean {
       if (!this.ngLink && !this.ngLink.length) return false;
 
+      console.log('doing click on tab', this.ngLink);
       this.$router.navigate(this.ngLink);
     }
 }
@@ -37,13 +38,14 @@ angular
         bindings: {
             label: '@',
             disabled: '=',
-            ngLink: '@?'
+            ngLink: '@?',
+            ngClick: '&'
         },
         controller: OsTab,
         controllerAs: 'osTab',
         transclude: true,
         template: `
-           <md-tab label="{{osTab.label}}" disabled="{{ osTabs.disabled }}" ng-link="{{ osTab.ngLink }}" md-on-select="osTab.click()">
+           <md-tab label="{{osTab.label}}" disabled="{{ osTabs.disabled }}" ng-click="osTab.ngClick()">
                 <div os-tab-transclude=""></div>
            </md-tab>
         `

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -16,7 +16,6 @@ export class OsTab implements IOsTab {
     click(): void|boolean {
       if (!this.ngLink && !this.ngLink.length) return false;
 
-      console.log('doing click on tab', this.ngLink);
       this.$router.navigate(this.ngLink);
     }
 }

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -29,12 +29,13 @@ angular
     .component('osTabs', {
         bindings: {
             mdDynamicHeight: '=?',
+            osSelected: '=?'
         },
         controller: OsTabs,
         controllerAs: 'osTabs',
         transclude: true,
         template: `
-           <md-tabs md-dynamic-height="{{ osTabs.mdDynamicHeight }}">
+           <md-tabs md-dynamic-height="{{ osTabs.mdDynamicHeight }}" md-selected="osTabs.osSelected">
                 <div os-tabs-transclude></div>
            </md-tabs>
         `


### PR DESCRIPTION
Due to https://github.com/angular/material/issues/6676 and https://github.com/angular/material/issues/7288, we shouldn't use md-on-select combined with ng-link, because multiple navigations occur.  Instead, I have added ng-click support so that routing can be delegate to the user