### PR TITLE
feat(osMapControlPolygon): Support osNoView and osIsActive

### DIFF
--- a/openlayers_custom.d.ts
+++ b/openlayers_custom.d.ts
@@ -1967,7 +1967,7 @@ declare module ol {
      * @param ref The object to use as this in listener.
      * @returns Unique key for the listener.
      */
-    un(type: Array<string>, listener: (event: MapBrowserEvent | DrawEvent) => void, ref?: any): any;
+    un(type: string|Array<string>, listener: (event: MapBrowserEvent | DrawEvent) => void, ref?: any): any;
 
     /**
      * Removes an event listener using the key returned by on() or once(). Note that using the ol.Observable.unByKey static function is to be preferred.

--- a/src/components/map-controls/polygon/polygon.directive.ts
+++ b/src/components/map-controls/polygon/polygon.directive.ts
@@ -7,10 +7,12 @@ export class PolygonTool implements ng.IDirective {
   public link:(scope:ng.IScope, iElement:ng.IAugmentedJQuery, iAttrs:ng.IAttributes, olCtrl:any) => void;
   public restrict = 'E';
   public require = '^openlayers';
-  public template = `<os-button variation="outline" colour="primary" ng-click="ctrl.toggle()">Polygon</os-button>`;
+  public template = `<os-button ng-if="!ctrl.noView" variation="outline" colour="primary" ng-click="ctrl.isActive = !ctrl.isActive">Polygon</os-button>`;
   public scope = {};
   public bindToController = {
-    featureLayer: '=osFeatureLayer'
+    featureLayer: '=osFeatureLayer',
+    isActive: '=osIsActive',
+    noView: '=osNoView'
   };
   public controllerAs = 'ctrl';
   public controller = PolygonToolController;
@@ -18,6 +20,14 @@ export class PolygonTool implements ng.IDirective {
   constructor(private $timeout:ng.ITimeoutService, private $window:ng.IWindowService, private olData, private ol: any) {
 
     PolygonTool.prototype.link = (scope:ng.IScope, iElement:ng.IAugmentedJQuery, iAttrs:ng.IAttributes, olCtrl:any) => {
+
+      //console.log('initialised with active', scope.ctrl.isActive);
+
+      scope.$watch('ctrl.isActive', (isActive: boolean) => {
+        if (isActive !== scope.ctrl.isToolActive()) {
+          scope.ctrl.toggle();
+        }
+      });
 
       function PolygonTool_OL() {
         ol.control.Control.call(this, {


### PR DESCRIPTION
osNoView allows a control to be created without any DOM.
osIsActive is a databound boolean to activate/deactivate the control.