### PR TITLE
Fix: OsButton always displaying as loading within firefox

### DIFF
--- a/demo/basic/index.html
+++ b/demo/basic/index.html
@@ -29,6 +29,7 @@
         <md-content layout="column" layout-align="center" flex="50">
             <div layout="row" layout-align="space-around">
                 <os-button>Button</os-button>
+                <os-button loading="true">Loading Button</os-button>
                 <os-button colour="primary">Primary</os-button>
                 <os-button colour="primary" ng-disabled="true">Disabled</os-button>
                 <os-button colour="accent">Accent</os-button>
@@ -36,6 +37,7 @@
             </div>
             <div layout="row" layout-align="space-around">
                 <os-button variation="raised">Button</os-button>
+                <os-button variation="raised" loading="true">Loading Button</os-button>
                 <os-button variation="raised" colour="primary">Primary</os-button>
                 <os-button variation="raised" colour="primary" ng-disabled="true">Disabled</os-button>
                 <os-button variation="raised" colour="accent">Accent</os-button>
@@ -43,10 +45,11 @@
             </div>
             <div layout="row" layout-align="space-around">
                 <os-button variation="fab">1</os-button>
-                <os-button variation="fab" colour="primary">2</os-button>
-                <os-button variation="fab" colour="primary" ng-disabled="true">3</os-button>
-                <os-button variation="fab" colour="accent">4</os-button>
-                <os-button variation="fab" colour="warn">5</os-button>
+                <os-button variation="fab" loading="true">2</os-button>
+                <os-button variation="fab" colour="primary">3</os-button>
+                <os-button variation="fab" colour="primary" ng-disabled="true">4</os-button>
+                <os-button variation="fab" colour="accent">5</os-button>
+                <os-button variation="fab" colour="warn">6</os-button>
             </div>
         </md-content>
     </section>

--- a/src/components/button/button.component.ts
+++ b/src/components/button/button.component.ts
@@ -104,7 +104,7 @@ angular
     template: `
             <md-button ng-disabled="osButton.disabled || osButton.loading" md-no-ink type="{{osButton.type}}" class="mdl-button mdl-js-button mdl-js-ripple-effect" ng-class="{loading: osButton.loading, 'md-hue-900': osButton.loading}" layout="row">
               <ng-transclude></ng-transclude>
-              <div class="loader">
+              <div class="loader" ng-show="osButton.loading">
                 <svg class="circular" viewBox="25 25 50 50">
                   <circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="3" stroke-miterlimit="10"/>
                 </svg>

--- a/src/components/button/docs/button.demo.html
+++ b/src/components/button/docs/button.demo.html
@@ -4,6 +4,7 @@
     <os-button variation="solid" colour="primary" ng-disabled="true">Disabled</os-button>
     <os-button variation="solid" colour="accent">Accent</os-button>
     <os-button variation="solid" colour="warn">Warn</os-button>
+    <os-button variation="solid" loading="true">Loading</os-button>
 </div>
 <div flex>
     <os-button variation="outline">Button</os-button>
@@ -11,6 +12,7 @@
     <os-button variation="outline" colour="primary" ng-disabled="true">Disabled</os-button>
     <os-button variation="outline" colour="accent">Accent</os-button>
     <os-button variation="outline" colour="warn">Warn</os-button>
+    <os-button variation="outline" loading="true">Loading</os-button>
 </div>
 <div flex>
     <os-button variation="super">Button</os-button>
@@ -18,4 +20,5 @@
     <os-button variation="super" colour="primary" ng-disabled="true">Disabled</os-button>
     <os-button variation="super" colour="accent">Accent</os-button>
     <os-button variation="super" colour="warn">Warn</os-button>
+    <os-button variation="super" loading="true">Loading</os-button>
 </div>


### PR DESCRIPTION
NOTE: PR #103 needs to be merged first.

Looks like firefox was implementing the css differently and so for simplicity when loading is not required I'm making the `div` invisible