### PR TITLE
Fix: disabled button within dialog failed in firefox

### DIFF
--- a/src/components/button/button.component.ts
+++ b/src/components/button/button.component.ts
@@ -10,7 +10,7 @@ export interface IOsButton {
 }
 
 interface IWindowService extends ng.IWindowService {
-  componentHandler: { upgradeElement(el:HTMLElement) };
+  componentHandler: { upgradeElements(el:HTMLElement) };
 }
 
 export class OsButton implements IOsButton {
@@ -46,7 +46,7 @@ export class OsButton implements IOsButton {
   }
 
   setDisabled() {
-    if (this.disabled) {
+    if (this.disabled || this.loading) {
       this.mdButton.attr('disabled', 'disabled');
     }
   }
@@ -82,7 +82,7 @@ export class OsButton implements IOsButton {
   $postLink() {
     if ('componentHandler' in this.$window) {
       // trigger MDL upgrade for button element
-      this.$window.componentHandler.upgradeElement(this.$element.children()[0]);
+      this.$window.componentHandler.upgradeElements(this.mdButton);
     }
   }
 

--- a/src/components/button/docs/button.demo.html
+++ b/src/components/button/docs/button.demo.html
@@ -4,6 +4,7 @@
     <os-button variation="solid" colour="primary" ng-disabled="true">Disabled</os-button>
     <os-button variation="solid" colour="accent">Accent</os-button>
     <os-button variation="solid" colour="warn">Warn</os-button>
+    <os-button variation="solid" loading="true">Loading</os-button>
 </div>
 <div flex>
     <os-button variation="outline">Button</os-button>
@@ -11,6 +12,7 @@
     <os-button variation="outline" colour="primary" ng-disabled="true">Disabled</os-button>
     <os-button variation="outline" colour="accent">Accent</os-button>
     <os-button variation="outline" colour="warn">Warn</os-button>
+    <os-button variation="outline" loading="true">Loading</os-button>
 </div>
 <div flex>
     <os-button variation="super">Button</os-button>
@@ -18,4 +20,5 @@
     <os-button variation="super" colour="primary" ng-disabled="true">Disabled</os-button>
     <os-button variation="super" colour="accent">Accent</os-button>
     <os-button variation="super" colour="warn">Warn</os-button>
+    <os-button variation="super" loading="true">Loading</os-button>
 </div>

--- a/test/unit/components/button/button_test.js
+++ b/test/unit/components/button/button_test.js
@@ -88,6 +88,12 @@ describe("osButton | ", function () {
 
     component = createComponent({disabled: false});
     expect(component.mdButtonSpy.attr).not.toHaveBeenCalled();
+
+    var component = createComponent({loading: true});
+    expect(component.mdButtonSpy.attr).toHaveBeenCalled();
+
+    component = createComponent({loading: false});
+    expect(component.mdButtonSpy.attr).not.toHaveBeenCalled();
   });
 
   it("should initialize MDL on element", function () {

--- a/test/unit/components/button/button_test.js
+++ b/test/unit/components/button/button_test.js
@@ -63,7 +63,7 @@ describe("osButton | ", function () {
   function createWindowSpy() {
     return {
       componentHandler: {
-        upgradeElement: jasmine.createSpy('upgradeElementSpy')
+        upgradeElements: jasmine.createSpy('upgradeElementsSpy')
       }
     };
   }
@@ -93,9 +93,9 @@ describe("osButton | ", function () {
   it("should initialize MDL on element", function () {
     var component = createComponent({colour: 'accent', variation: 'solid'});
 
-    expect(component.windowSpy.componentHandler.upgradeElement).not.toHaveBeenCalled();
+    expect(component.windowSpy.componentHandler.upgradeElements).not.toHaveBeenCalled();
     component.controller.$postLink();
-    expect(component.windowSpy.componentHandler.upgradeElement).toHaveBeenCalledTimes(1);
+    expect(component.windowSpy.componentHandler.upgradeElements).toHaveBeenCalledTimes(1);
   });
 
   it("should not initialize MDL on element if componentHandler not available", function () {


### PR DESCRIPTION
NOTE: PR #104 needs to be merged first.

There was an exception within Firefox when trying to load a dialog which contains a disabled button. Reading on MDLs issue list there looks to be a couple of issues with this upgrade and downgrade of elements, but I couldn't find anyone have our specific problem , but using `updgradeElements` instead looks to resolve the issue.
